### PR TITLE
Add basic army creation flow

### DIFF
--- a/app/.server/db.ts
+++ b/app/.server/db.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from "@prisma/client";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 
-export type { Game, Terrain, User } from "@prisma/client";
+export type { Game, Terrain, User, Army } from "@prisma/client";
 
 // Basic client for use in validations
 const prisma = new PrismaClient();

--- a/app/.server/db.ts
+++ b/app/.server/db.ts
@@ -65,6 +65,14 @@ const UnitCreateInput = z.object({
   color: z.string().refine(isHexColor, "Color must be a hex color code."),
 });
 
+const MiniatureCreateInput = z.object({
+  name: shortTextValidations,
+  stats: longTextValidations,
+  gear: longTextValidations,
+  notes: longTextValidations,
+  count: z.number().int().min(MIN_REQUIRED_NUMBER),
+});
+
 const db = new PrismaClient().$extends({
   query: {
     user: {
@@ -119,6 +127,20 @@ const db = new PrismaClient().$extends({
         await Promise.all(
           (Array.isArray(args.data) ? args.data : [args.data]).map((data) =>
             UnitCreateInput.parseAsync(data),
+          ),
+        );
+        return query(args);
+      },
+    },
+    miniature: {
+      create: async ({ args, query }) => {
+        await MiniatureCreateInput.parseAsync(args.data);
+        return query(args);
+      },
+      createMany: async ({ args, query }) => {
+        await Promise.all(
+          (Array.isArray(args.data) ? args.data : [args.data]).map((data) =>
+            MiniatureCreateInput.parseAsync(data),
           ),
         );
         return query(args);

--- a/app/.server/db.ts
+++ b/app/.server/db.ts
@@ -2,7 +2,15 @@ import { PrismaClient } from "@prisma/client";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 
-export type { Game, Terrain, User, Army } from "@prisma/client";
+export type {
+  Game,
+  Terrain,
+  User,
+  Army,
+  BaseShape,
+  Unit,
+  Miniature,
+} from "@prisma/client";
 
 // Basic client for use in validations
 const prisma = new PrismaClient();

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -1,0 +1,14 @@
+import { ButtonProps, Button as ChakraButton } from "@chakra-ui/react";
+import { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+} & ButtonProps;
+
+export default function Button({ children, ...buttonProps }: Props) {
+  return (
+    <ChakraButton width="100%" marginBottom="1rem" {...buttonProps}>
+      {children}
+    </ChakraButton>
+  );
+}

--- a/app/components/FormField.tsx
+++ b/app/components/FormField.tsx
@@ -1,0 +1,43 @@
+import {
+  FormControl,
+  FormLabel,
+  FormHelperText,
+  FormErrorMessage,
+} from "@chakra-ui/react";
+import { ReactNode } from "react";
+
+type Props = {
+  isRequired?: boolean;
+  label: string;
+  helperText?: string;
+  errors?: string[];
+  children: ReactNode;
+};
+
+export default function FormField({
+  isRequired = false,
+  label,
+  helperText = "",
+  errors = [],
+  children,
+}: Props) {
+  const isInvalid = errors.length > 0;
+
+  return (
+    <FormControl
+      isRequired={isRequired}
+      marginTop="1rem"
+      marginBottom="1rem"
+      isInvalid={isInvalid}
+    >
+      <FormLabel>{label}</FormLabel>
+      {children}
+      {errors.map((message) => (
+        <FormErrorMessage key={message}>{message}</FormErrorMessage>
+      ))}
+      {!isInvalid && helperText ? (
+        <FormHelperText>{helperText}</FormHelperText>
+      ) : null}
+    </FormControl>
+  );
+}

--- a/app/components/PageHeading.tsx
+++ b/app/components/PageHeading.tsx
@@ -1,0 +1,19 @@
+import { Heading } from "@chakra-ui/react";
+import { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function PageHeading({ children }: Props) {
+  return (
+    <Heading
+      as="h1"
+      size={{ base: "lg", lg: "2xl" }}
+      margin="1rem"
+      textAlign="center"
+    >
+      {children}
+    </Heading>
+  );
+}

--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -1,0 +1,7 @@
+import Button from "./Button";
+import FormField from "./FormField";
+import PageHeading from "./PageHeading";
+import Spinner from "./Spinner";
+import TableTop from "./Tabletop";
+
+export { Button, FormField, PageHeading, Spinner, TableTop };

--- a/app/routes/_auth.account.tsx
+++ b/app/routes/_auth.account.tsx
@@ -22,7 +22,7 @@ export default function AccountPage() {
   return (
     <>
       <PageHeading>{username}</PageHeading>
-      <Link to={"/games/new"}>
+      <Link to={"/armies/new"}>
         <Button>Build an army</Button>
       </Link>
     </>

--- a/app/routes/_auth.account.tsx
+++ b/app/routes/_auth.account.tsx
@@ -1,9 +1,8 @@
-import { Button, Heading } from "@chakra-ui/react";
 import { MetaFunction } from "@remix-run/node";
 import { Link, useOutletContext } from "@remix-run/react";
 
 import type { User } from "~/.server/db";
-import PageHeading from "~/components/PageHeading";
+import { PageHeading, Button } from "~/components";
 
 export const meta: MetaFunction = () => {
   return [
@@ -24,7 +23,7 @@ export default function AccountPage() {
     <>
       <PageHeading>{username}</PageHeading>
       <Link to={"/games/new"}>
-        <Button width="100%">Start a game</Button>
+        <Button>Build an army</Button>
       </Link>
     </>
   );

--- a/app/routes/_auth.account.tsx
+++ b/app/routes/_auth.account.tsx
@@ -1,0 +1,37 @@
+import { Button, Heading } from "@chakra-ui/react";
+import { MetaFunction } from "@remix-run/node";
+import { Link, useOutletContext } from "@remix-run/react";
+
+import type { User } from "~/.server/db";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Wargame by Mail: Your account" },
+    {
+      name: "description",
+      content: "Your account info and settings.",
+    },
+  ];
+};
+
+export default function AccountPage() {
+  const {
+    user: { username },
+  } = useOutletContext<{ user: User }>();
+
+  return (
+    <>
+      <Heading
+        as="h1"
+        size={{ base: "lg", lg: "2xl" }}
+        margin="1rem"
+        textAlign="center"
+      >
+        {username}
+      </Heading>
+      <Link to={"/games/new"}>
+        <Button width="100%">Start a game</Button>
+      </Link>
+    </>
+  );
+}

--- a/app/routes/_auth.account.tsx
+++ b/app/routes/_auth.account.tsx
@@ -3,6 +3,7 @@ import { MetaFunction } from "@remix-run/node";
 import { Link, useOutletContext } from "@remix-run/react";
 
 import type { User } from "~/.server/db";
+import PageHeading from "~/components/PageHeading";
 
 export const meta: MetaFunction = () => {
   return [
@@ -21,14 +22,7 @@ export default function AccountPage() {
 
   return (
     <>
-      <Heading
-        as="h1"
-        size={{ base: "lg", lg: "2xl" }}
-        margin="1rem"
-        textAlign="center"
-      >
-        {username}
-      </Heading>
+      <PageHeading>{username}</PageHeading>
       <Link to={"/games/new"}>
         <Button width="100%">Start a game</Button>
       </Link>

--- a/app/routes/_auth.armies.$armyId.units.new.tsx
+++ b/app/routes/_auth.armies.$armyId.units.new.tsx
@@ -1,0 +1,138 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, json } from "@remix-run/node";
+import {
+  Form,
+  Link,
+  MetaFunction,
+  Params,
+  redirect,
+  useLoaderData,
+} from "@remix-run/react";
+import invariant from "tiny-invariant";
+import * as R from "ramda";
+import db, { Army, BaseShape, Unit } from "~/.server/db";
+import { Button, FormField, PageHeading } from "~/components";
+import { Input, Select, Textarea } from "@chakra-ui/react";
+
+const SUBMIT_TYPES = ["save", "addMiniatures"];
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Wargame by Mail: Add a unit to your army" },
+    {
+      name: "description",
+      content: "Add a unit with one or more models to your army.",
+    },
+  ];
+};
+
+const fetchArmy = (params: Params<string>) =>
+  R.pipe(
+    R.prop("armyId"),
+    R.tap((armyId) => invariant(typeof armyId === "string")),
+    parseInt,
+    R.objOf("id"),
+    R.objOf("where"),
+    db.army.findUniqueOrThrow,
+    R.andThen(R.objOf("army")),
+  )(params);
+
+const fetchBaseShapes = () =>
+  R.pipe(db.baseShape.findMany, R.andThen(R.objOf("baseShapes")))();
+
+export function loader({ params }: LoaderFunctionArgs) {
+  return R.pipe(
+    (params) => Promise.all([fetchArmy(params), fetchBaseShapes()]),
+    R.andThen(R.mergeAll<{ army: Army }, [{ baseShapes: BaseShape[] }]>),
+    R.andThen(json),
+  )(params);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const submitType = formData.get("submit");
+
+  invariant(
+    typeof submitType === "string" && SUBMIT_TYPES.includes(submitType),
+  );
+
+  const unit = await R.pipe(
+    R.invoker(0, "entries"),
+    R.map(([key, value]) => [
+      key,
+      Number.isNaN(parseInt(value)) ? value : parseInt(value),
+    ]),
+    Object.fromEntries,
+    R.omit(["submit"])<Unit & { submit: string }>,
+    R.objOf("data")<Unit>,
+    db.unit.create,
+  )(formData);
+
+  if (submitType === "save") return json({ unit });
+
+  if (submitType === "addMiniatures")
+    return redirect(`/units/${unit.id}/miniatures/new`);
+}
+
+export default function NewUnitPage() {
+  const { army, baseShapes } = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <PageHeading>Add a unit to {army.name}</PageHeading>
+      <Form method="post">
+        <FormField isRequired label="Name">
+          <Input type="text" name="name" />
+        </FormField>
+        <FormField label="Stats">
+          <Textarea name="stats" />
+        </FormField>
+        <FormField label="Gear">
+          <Textarea name="gear" />
+        </FormField>
+        <FormField label="Notes">
+          <Textarea name="notes" />
+        </FormField>
+        <FormField isRequired label="Base shape">
+          <Select placeholder="Select models' base shape" name="baseShapeId">
+            {baseShapes.map(({ name, id }) => (
+              <option key={id} value={id}>
+                {name}
+              </option>
+            ))}
+          </Select>
+        </FormField>
+        <FormField isRequired label="Base length (mm)">
+          <Input
+            type="number"
+            name="baseLength"
+            min={1}
+            step={1}
+            defaultValue={25}
+          />
+        </FormField>
+        <FormField isRequired label="Base width (mm)">
+          <Input
+            type="number"
+            name="baseWidth"
+            min={1}
+            step={1}
+            defaultValue={25}
+          />
+        </FormField>
+        <FormField isRequired label="Model color">
+          <Input type="color" name="color" />
+        </FormField>
+        <Input type="hidden" name="armyId" value={army.id} />
+        <Link to={`/armies/${army.id}`}>
+          <Button>Back</Button>
+        </Link>
+        <Button type="submit" value="save" name="submit">
+          Save
+        </Button>
+        <Button type="submit" value="addMiniatures" name="submit">
+          Add models
+        </Button>
+      </Form>
+    </>
+  );
+}

--- a/app/routes/_auth.armies.$armyId.units.new.tsx
+++ b/app/routes/_auth.armies.$armyId.units.new.tsx
@@ -123,9 +123,6 @@ export default function NewUnitPage() {
           <Input type="color" name="color" />
         </FormField>
         <Input type="hidden" name="armyId" value={army.id} />
-        <Link to={`/armies/${army.id}`}>
-          <Button>Back</Button>
-        </Link>
         <Button type="submit" value="save" name="submit">
           Save
         </Button>
@@ -133,6 +130,9 @@ export default function NewUnitPage() {
           Add models
         </Button>
       </Form>
+      <Link to={"/armies/new"}>
+        <Button>Back to army</Button>
+      </Link>
     </>
   );
 }

--- a/app/routes/_auth.armies.$armyId.units.new.tsx
+++ b/app/routes/_auth.armies.$armyId.units.new.tsx
@@ -5,6 +5,7 @@ import {
   MetaFunction,
   Params,
   redirect,
+  useActionData,
   useLoaderData,
 } from "@remix-run/react";
 import invariant from "tiny-invariant";
@@ -12,8 +13,12 @@ import * as R from "ramda";
 import db, { Army, BaseShape, Unit } from "~/.server/db";
 import { Button, FormField, PageHeading } from "~/components";
 import { Input, Select, Textarea } from "@chakra-ui/react";
+import { ZodError } from "zod";
+
+type FormErrors = Partial<Record<keyof Unit, string[]>>;
 
 const SUBMIT_TYPES = ["save", "addMiniatures"];
+const EMPTY_FORM_ERRORS: FormErrors = {};
 
 export const meta: MetaFunction = () => {
   return [
@@ -55,41 +60,59 @@ export async function action({ request }: ActionFunctionArgs) {
     typeof submitType === "string" && SUBMIT_TYPES.includes(submitType),
   );
 
-  const unit = await R.pipe(
-    R.invoker(0, "entries"),
-    R.map(([key, value]) => [
-      key,
-      Number.isNaN(parseInt(value)) ? value : parseInt(value),
-    ]),
-    Object.fromEntries,
-    R.omit(["submit"])<Unit & { submit: string }>,
-    R.objOf("data")<Unit>,
-    db.unit.create,
-  )(formData);
+  try {
+    const unit = await R.pipe(
+      R.invoker(0, "entries"),
+      R.map(([key, value]) => [
+        key,
+        Number.isNaN(parseInt(value)) ? value : parseInt(value),
+      ]),
+      Object.fromEntries,
+      R.omit(["submit"])<Unit & { submit: string }>,
+      R.objOf("data")<Unit>,
+      db.unit.create,
+    )(formData);
 
-  if (submitType === "save") return json({ unit });
+    if (submitType === "save") return json({ unit, errors: EMPTY_FORM_ERRORS });
 
-  if (submitType === "addMiniatures")
-    return redirect(`/units/${unit.id}/miniatures/new`);
+    if (submitType === "addMiniatures")
+      return redirect(`/units/${unit.id}/miniatures/new`);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const errors = error.issues.reduce((aggValue, currValue) => {
+        const key = currValue.path[0] as keyof FormErrors;
+        invariant(typeof key === "string");
+
+        return {
+          ...aggValue,
+          [key]: [...(aggValue[key] || []), currValue.message],
+        };
+      }, EMPTY_FORM_ERRORS);
+      return json({ errors });
+    }
+
+    throw error;
+  }
 }
 
 export default function NewUnitPage() {
   const { army, baseShapes } = useLoaderData<typeof loader>();
+  const { errors } = useActionData<typeof action>() || {};
 
   return (
     <>
       <PageHeading>Add a unit to {army.name}</PageHeading>
       <Form method="post">
-        <FormField isRequired label="Name">
+        <FormField isRequired label="Name" errors={errors?.name}>
           <Input type="text" name="name" />
         </FormField>
-        <FormField label="Stats">
+        <FormField label="Stats" errors={errors?.stats}>
           <Textarea name="stats" />
         </FormField>
-        <FormField label="Gear">
+        <FormField label="Gear" errors={errors?.gear}>
           <Textarea name="gear" />
         </FormField>
-        <FormField label="Notes">
+        <FormField label="Notes" errors={errors?.notes}>
           <Textarea name="notes" />
         </FormField>
         <FormField isRequired label="Base shape">
@@ -101,7 +124,11 @@ export default function NewUnitPage() {
             ))}
           </Select>
         </FormField>
-        <FormField isRequired label="Base length (mm)">
+        <FormField
+          isRequired
+          label="Base length (mm)"
+          errors={errors?.baseLength}
+        >
           <Input
             type="number"
             name="baseLength"
@@ -110,7 +137,11 @@ export default function NewUnitPage() {
             defaultValue={25}
           />
         </FormField>
-        <FormField isRequired label="Base width (mm)">
+        <FormField
+          isRequired
+          label="Base width (mm)"
+          errors={errors?.baseWidth}
+        >
           <Input
             type="number"
             name="baseWidth"
@@ -119,7 +150,7 @@ export default function NewUnitPage() {
             defaultValue={25}
           />
         </FormField>
-        <FormField isRequired label="Model color">
+        <FormField isRequired label="Model color" errors={errors?.color}>
           <Input type="color" name="color" />
         </FormField>
         <Input type="hidden" name="armyId" value={army.id} />

--- a/app/routes/_auth.armies.new.tsx
+++ b/app/routes/_auth.armies.new.tsx
@@ -9,11 +9,15 @@ import {
 } from "@remix-run/react";
 import * as R from "ramda";
 import invariant from "tiny-invariant";
+import { ZodError } from "zod";
 import db, { Army } from "~/.server/db";
 
 import { Button, FormField, PageHeading } from "~/components";
 
+type FormErrors = Partial<Record<keyof Army, string[]>>;
+
 const SUBMIT_TYPES = ["save", "addUnits"];
+const EMPTY_FORM_ERRORS: FormErrors = {};
 
 export const meta: MetaFunction = () => {
   return [
@@ -33,41 +37,54 @@ export async function action({ request }: ActionFunctionArgs) {
     typeof submitType === "string" && SUBMIT_TYPES.includes(submitType),
   );
 
-  const army = await R.pipe(
-    Object.fromEntries,
-    R.omit(["submit"])<Army & { submit: string }>,
-    R.objOf("data")<Army>,
-    db.army.create,
-  )(formData);
+  try {
+    const army = await R.pipe(
+      Object.fromEntries,
+      R.omit(["submit"])<Army & { submit: string }>,
+      R.objOf("data")<Army>,
+      db.army.create,
+    )(formData);
 
-  if (submitType === "save") return json({ army });
+    if (submitType === "save") return json({ errors: EMPTY_FORM_ERRORS });
 
-  if (submitType === "addUnits")
-    return redirect(`/armies/${army.id}/units/new`);
+    if (submitType === "addUnits")
+      return redirect(`/armies/${army.id}/units/new`);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const errors = error.issues.reduce((aggValue, currValue) => {
+        const key = currValue.path[0] as keyof FormErrors;
+        invariant(typeof key === "string");
+
+        return {
+          ...aggValue,
+          [key]: [...(aggValue[key] || []), currValue.message],
+        };
+      }, EMPTY_FORM_ERRORS);
+      return json({ errors });
+    }
+
+    throw error;
+  }
 }
 
 export default function NewArmyPage() {
-  const { army } = useActionData<typeof action>() || {};
+  const { errors } = useActionData<typeof action>() || {};
 
   return (
     <>
       <PageHeading>Build a new army</PageHeading>
       <Form method="post">
-        <FormField isRequired label="Name">
-          <Input type="text" name="name" defaultValue={army?.name} />
+        <FormField isRequired label="Name" errors={errors?.name}>
+          <Input type="text" name="name" />
         </FormField>
-        <FormField isRequired label="Game system">
-          <Input
-            type="text"
-            name="gameSystem"
-            defaultValue={army?.gameSystem}
-          />
+        <FormField isRequired label="Game system" errors={errors?.gameSystem}>
+          <Input type="text" name="gameSystem" />
         </FormField>
-        <FormField isRequired label="Faction">
-          <Input type="text" name="faction" defaultValue={army?.faction} />
+        <FormField isRequired label="Faction" errors={errors?.faction}>
+          <Input type="text" name="faction" />
         </FormField>
-        <FormField label="Description">
-          <Textarea name="description" defaultValue={army?.description} />
+        <FormField label="Description" errors={errors?.description}>
+          <Textarea name="description" />
         </FormField>
         <Button type="submit" value="save" name="submit">
           Save

--- a/app/routes/_auth.armies.new.tsx
+++ b/app/routes/_auth.armies.new.tsx
@@ -1,0 +1,84 @@
+import { Input, Textarea } from "@chakra-ui/react";
+import { ActionFunctionArgs, json } from "@remix-run/node";
+import {
+  Form,
+  Link,
+  MetaFunction,
+  redirect,
+  useActionData,
+} from "@remix-run/react";
+import * as R from "ramda";
+import invariant from "tiny-invariant";
+import db, { Army } from "~/.server/db";
+
+import { Button, FormField, PageHeading } from "~/components";
+
+const SUBMIT_TYPES = ["save", "addUnits"];
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Wargame by Mail: Build a new army" },
+    {
+      name: "description",
+      content: "Build a new army for use in your games.",
+    },
+  ];
+};
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const submitType = formData.get("submit");
+
+  invariant(
+    typeof submitType === "string" && SUBMIT_TYPES.includes(submitType),
+  );
+
+  const army = await R.pipe(
+    Object.fromEntries,
+    R.omit(["submit"])<Army & { submit: string }>,
+    R.objOf("data")<Army>,
+    db.army.create,
+  )(formData);
+
+  if (submitType === "save") return json({ army });
+
+  if (submitType === "addUnits")
+    return redirect(`/armies/${army.id}/units/new`);
+}
+
+export default function NewArmyPage() {
+  const { army } = useActionData<typeof action>() || {};
+
+  return (
+    <>
+      <PageHeading>Build a new army</PageHeading>
+      <Form method="post">
+        <FormField isRequired label="Name">
+          <Input type="text" name="name" defaultValue={army?.name} />
+        </FormField>
+        <FormField isRequired label="Game system">
+          <Input
+            type="text"
+            name="gameSystem"
+            defaultValue={army?.gameSystem}
+          />
+        </FormField>
+        <FormField isRequired label="Faction">
+          <Input type="text" name="faction" defaultValue={army?.faction} />
+        </FormField>
+        <FormField label="Description">
+          <Textarea name="description" defaultValue={army?.description} />
+        </FormField>
+        <Link to="/account">
+          <Button>Back</Button>
+        </Link>
+        <Button type="submit" value="save" name="submit">
+          Save
+        </Button>
+        <Button type="submit" value="addUnits" name="submit">
+          Add units
+        </Button>
+      </Form>
+    </>
+  );
+}

--- a/app/routes/_auth.armies.new.tsx
+++ b/app/routes/_auth.armies.new.tsx
@@ -69,9 +69,6 @@ export default function NewArmyPage() {
         <FormField label="Description">
           <Textarea name="description" defaultValue={army?.description} />
         </FormField>
-        <Link to="/account">
-          <Button>Back</Button>
-        </Link>
         <Button type="submit" value="save" name="submit">
           Save
         </Button>
@@ -79,6 +76,9 @@ export default function NewArmyPage() {
           Add units
         </Button>
       </Form>
+      <Link to="/account">
+        <Button>Back to account</Button>
+      </Link>
     </>
   );
 }

--- a/app/routes/_auth.tsx
+++ b/app/routes/_auth.tsx
@@ -1,9 +1,7 @@
 import {
   Avatar,
   Box,
-  Button,
   Container,
-  Heading,
   HStack,
   Menu,
   MenuButton,
@@ -11,7 +9,7 @@ import {
   MenuList,
 } from "@chakra-ui/react";
 import { json, LoaderFunctionArgs } from "@remix-run/node";
-import { Form, Link, useLoaderData } from "@remix-run/react";
+import { Form, Link, Outlet, useLoaderData } from "@remix-run/react";
 
 import { authenticator } from "~/.server/auth";
 
@@ -23,10 +21,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return json({ user });
 }
 
-export default function AccountPage() {
-  const {
-    user: { username, id },
-  } = useLoaderData<typeof loader>();
+export default function AuthenticatedPage() {
+  const { user } = useLoaderData<typeof loader>();
 
   return (
     <>
@@ -34,11 +30,11 @@ export default function AccountPage() {
         <HStack justifyContent="end">
           <Menu>
             <MenuButton margin="1rem">
-              <Avatar name={username}></Avatar>
+              <Avatar name={user.username} />
             </MenuButton>
             <MenuList>
               <MenuItem>
-                <Link to={`/users/${id}`}>Account page</Link>
+                <Link to={`/users/${user.id}`}>Account page</Link>
               </MenuItem>
               <Form method="post" action="/logout">
                 <MenuItem type="submit">Log out</MenuItem>
@@ -48,17 +44,7 @@ export default function AccountPage() {
         </HStack>
       </Box>
       <Container>
-        <Heading
-          as="h1"
-          size={{ base: "lg", lg: "2xl" }}
-          margin="1rem"
-          textAlign="center"
-        >
-          {username}
-        </Heading>
-        <Link to={"/games/new"}>
-          <Button width="100%">Start a game</Button>
-        </Link>
+        <Outlet context={{ user }} />
       </Container>
     </>
   );

--- a/app/routes/_auth.units.$unitId.miniatures.new.tsx
+++ b/app/routes/_auth.units.$unitId.miniatures.new.tsx
@@ -1,0 +1,89 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, json } from "@remix-run/node";
+import {
+  Form,
+  Link,
+  MetaFunction,
+  Params,
+  redirect,
+  useLoaderData,
+} from "@remix-run/react";
+import invariant from "tiny-invariant";
+import * as R from "ramda";
+import db, { Miniature } from "~/.server/db";
+import { Button, FormField, PageHeading } from "~/components";
+import { Input, Textarea } from "@chakra-ui/react";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Wargame by Mail: Add a model to your unit" },
+    {
+      name: "description",
+      content: "Add one or more models to your unit.",
+    },
+  ];
+};
+
+const fetchUnit = (params: Params<string>) =>
+  R.pipe(
+    R.prop("unitId"),
+    R.tap((unitId) => invariant(typeof unitId === "string")),
+    parseInt,
+    R.objOf("id"),
+    R.objOf("where"),
+    db.unit.findUniqueOrThrow,
+    R.andThen(R.objOf("unit")),
+  )(params);
+
+export function loader({ params }: LoaderFunctionArgs) {
+  return R.pipe(fetchUnit, R.andThen(json))(params);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  return R.pipe(
+    R.invoker(0, "formData"),
+    R.andThen(R.invoker(0, "entries")),
+    R.andThen(
+      R.map(([key, value]) => [
+        key,
+        Number.isNaN(parseInt(value)) ? value : parseInt(value),
+      ]),
+    ),
+    R.andThen(Object.fromEntries),
+    R.andThen(R.objOf("data")<Miniature>),
+    R.andThen(db.miniature.create),
+    R.andThen(R.objOf("miniature")<Miniature>),
+    R.andThen(json),
+  )(request);
+}
+
+export default function NewUnitPage() {
+  const { unit } = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <PageHeading>Add a model to {unit.name}</PageHeading>
+      <Form method="post">
+        <FormField isRequired label="Name">
+          <Input type="text" name="name" />
+        </FormField>
+        <FormField label="Stats">
+          <Textarea name="stats" />
+        </FormField>
+        <FormField label="Gear">
+          <Textarea name="gear" />
+        </FormField>
+        <FormField label="Notes">
+          <Textarea name="notes" />
+        </FormField>
+        <FormField isRequired label="How many?">
+          <Input type="number" name="count" min={1} step={1} defaultValue={1} />
+        </FormField>
+        <Input type="hidden" name="unitId" value={unit.id} />
+        <Button type="submit">Save</Button>
+      </Form>
+      <Link to={`/armies/${unit.armyId}/units/new`}>
+        <Button>Back to unit</Button>
+      </Link>
+    </>
+  );
+}

--- a/app/routes/_auth.units.$unitId.miniatures.new.tsx
+++ b/app/routes/_auth.units.$unitId.miniatures.new.tsx
@@ -4,7 +4,7 @@ import {
   Link,
   MetaFunction,
   Params,
-  redirect,
+  useActionData,
   useLoaderData,
 } from "@remix-run/react";
 import invariant from "tiny-invariant";
@@ -12,6 +12,10 @@ import * as R from "ramda";
 import db, { Miniature } from "~/.server/db";
 import { Button, FormField, PageHeading } from "~/components";
 import { Input, Textarea } from "@chakra-ui/react";
+import { ZodError } from "zod";
+
+type FormErrors = Partial<Record<keyof Miniature, string[]>>;
+const EMPTY_FORM_ERRORS: FormErrors = {};
 
 export const meta: MetaFunction = () => {
   return [
@@ -39,43 +43,60 @@ export function loader({ params }: LoaderFunctionArgs) {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  return R.pipe(
-    R.invoker(0, "formData"),
-    R.andThen(R.invoker(0, "entries")),
-    R.andThen(
-      R.map(([key, value]) => [
-        key,
-        Number.isNaN(parseInt(value)) ? value : parseInt(value),
-      ]),
-    ),
-    R.andThen(Object.fromEntries),
-    R.andThen(R.objOf("data")<Miniature>),
-    R.andThen(db.miniature.create),
-    R.andThen(R.objOf("miniature")<Miniature>),
-    R.andThen(json),
-  )(request);
+  try {
+    await R.pipe(
+      R.invoker(0, "formData"),
+      R.andThen(R.invoker(0, "entries")),
+      R.andThen(
+        R.map(([key, value]) => [
+          key,
+          Number.isNaN(parseInt(value)) ? value : parseInt(value),
+        ]),
+      ),
+      R.andThen(Object.fromEntries),
+      R.andThen(R.objOf("data")<Miniature>),
+      R.andThen(db.miniature.create),
+    )(request);
+    return json({ errors: EMPTY_FORM_ERRORS });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const errors = error.issues.reduce((aggValue, currValue) => {
+        const key = currValue.path[0] as keyof FormErrors;
+        invariant(typeof key === "string");
+
+        return {
+          ...aggValue,
+          [key]: [...(aggValue[key] || []), currValue.message],
+        };
+      }, EMPTY_FORM_ERRORS);
+      return json({ errors });
+    }
+
+    throw error;
+  }
 }
 
 export default function NewUnitPage() {
   const { unit } = useLoaderData<typeof loader>();
+  const { errors } = useActionData<typeof action>() || {};
 
   return (
     <>
       <PageHeading>Add a model to {unit.name}</PageHeading>
       <Form method="post">
-        <FormField isRequired label="Name">
+        <FormField isRequired label="Name" errors={errors?.name}>
           <Input type="text" name="name" />
         </FormField>
-        <FormField label="Stats">
+        <FormField label="Stats" errors={errors?.stats}>
           <Textarea name="stats" />
         </FormField>
-        <FormField label="Gear">
+        <FormField label="Gear" errors={errors?.gear}>
           <Textarea name="gear" />
         </FormField>
-        <FormField label="Notes">
+        <FormField label="Notes" errors={errors?.notes}>
           <Textarea name="notes" />
         </FormField>
-        <FormField isRequired label="How many?">
+        <FormField isRequired label="How many?" errors={errors?.count}>
           <Input type="number" name="count" min={1} step={1} defaultValue={1} />
         </FormField>
         <Input type="hidden" name="unitId" value={unit.id} />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,13 +1,7 @@
-import {
-  Heading,
-  Text,
-  Container,
-  Box,
-  VStack,
-  Button,
-} from "@chakra-ui/react";
+import { Heading, Text, Container, Box, VStack } from "@chakra-ui/react";
 import type { MetaFunction } from "@remix-run/node";
 import { Link } from "@remix-run/react";
+import { Button } from "~/components";
 
 export const meta: MetaFunction = () => {
   return [
@@ -35,12 +29,10 @@ export default function Index() {
         </Box>
         <Box width="100%">
           <Link to={"/login"}>
-            <Button width="100%" marginBottom="1rem">
-              Log in
-            </Button>
+            <Button marginBottom="1rem">Log in</Button>
           </Link>
           <Link to={"/signup"}>
-            <Button width="100%">Sign up</Button>
+            <Button>Sign up</Button>
           </Link>
         </Box>
       </VStack>

--- a/app/routes/games.$gameId.play.tsx
+++ b/app/routes/games.$gameId.play.tsx
@@ -1,6 +1,7 @@
 import { Box, Container, Heading, VStack } from "@chakra-ui/react";
 import { MetaFunction } from "@remix-run/node";
 import { ClientOnly } from "remix-utils/client-only";
+import PageHeading from "~/components/PageHeading";
 
 import Spinner from "~/components/Spinner";
 import TableTop from "~/components/Tabletop";
@@ -20,14 +21,7 @@ export const meta: MetaFunction = () => {
 export default function Game() {
   return (
     <Container>
-      <Heading
-        as="h1"
-        size={{ base: "lg", lg: "2xl" }}
-        margin="1rem"
-        textAlign="center"
-      >
-        Play Game
-      </Heading>
+      <PageHeading>Play Game</PageHeading>
       <VStack>
         <ClientOnly fallback={<Spinner minHeight={MIN_TABLE_HEIGHT} />}>
           {() => <TableTop minHeight={MIN_TABLE_HEIGHT} />}

--- a/app/routes/games.$gameId.play.tsx
+++ b/app/routes/games.$gameId.play.tsx
@@ -1,10 +1,8 @@
-import { Box, Container, Heading, VStack } from "@chakra-ui/react";
+import { Box, Container, VStack } from "@chakra-ui/react";
 import { MetaFunction } from "@remix-run/node";
 import { ClientOnly } from "remix-utils/client-only";
-import PageHeading from "~/components/PageHeading";
 
-import Spinner from "~/components/Spinner";
-import TableTop from "~/components/Tabletop";
+import { PageHeading, Spinner, TableTop } from "~/components";
 
 const MIN_TABLE_HEIGHT = "55vh";
 

--- a/app/routes/games.$gameId.terrains.new.tsx
+++ b/app/routes/games.$gameId.terrains.new.tsx
@@ -1,9 +1,6 @@
 import { DeleteIcon, EditIcon } from "@chakra-ui/icons";
 import {
   Container,
-  Heading,
-  FormControl,
-  FormLabel,
   Input,
   Box,
   VStack,
@@ -33,6 +30,7 @@ import db from "~/.server/db";
 import Spinner from "~/components/Spinner";
 import TableTop from "~/components/Tabletop";
 import PageHeading from "~/components/PageHeading";
+import FormField from "~/components/FormField";
 
 const INCHES_PER_FOOT = 12;
 const BOARD_WIDTH_IN = 6 * INCHES_PER_FOOT;
@@ -51,7 +49,6 @@ export const meta: MetaFunction = () => {
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const { gameId } = params;
-
   invariant(gameId, "Expected gameId param");
 
   return json({
@@ -97,12 +94,10 @@ export default function NewTerrain() {
         </ClientOnly>
         <Box marginBottom="1rem" overflow="scroll" maxHeight="34vh">
           <Form method="post" reloadDocument>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Name</FormLabel>
+            <FormField isRequired label="Name">
               <Input type="text" name="name" />
-            </FormControl>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Type</FormLabel>
+            </FormField>
+            <FormField isRequired label="Type">
               <Select placeholder="Select terrain type" name="typeId">
                 {terrainTypes.map(({ name, id }) => (
                   <option key={id} value={id}>
@@ -110,9 +105,8 @@ export default function NewTerrain() {
                   </option>
                 ))}
               </Select>
-            </FormControl>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Shape</FormLabel>
+            </FormField>
+            <FormField isRequired label="Shape">
               <Select placeholder="Select terrain shape" name="shapeId">
                 {terrainShapes.map(({ name, id }) => (
                   <option key={id} value={id}>
@@ -120,58 +114,51 @@ export default function NewTerrain() {
                   </option>
                 ))}
               </Select>
-            </FormControl>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Width (in)</FormLabel>
+            </FormField>
+            <FormField isRequired label="Width (in)">
               <Input
                 type="number"
-                min={1}
-                step={1}
-                defaultValue={1}
                 name="width"
-              />
-            </FormControl>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Height (in)</FormLabel>
-              <Input
-                type="number"
                 min={1}
                 step={1}
                 defaultValue={1}
-                name="height"
               />
-            </FormControl>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Angle (degrees)</FormLabel>
-              <Input type="number" step={1} defaultValue={0} name="angle" />
-            </FormControl>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Center x-coordinate (in)</FormLabel>
+            </FormField>
+            <FormField isRequired label="Height (in)">
               <Input
                 type="number"
+                name="height"
+                min={1}
+                step={1}
+                defaultValue={1}
+              />
+            </FormField>
+            <FormField isRequired label="Angle (degrees)">
+              <Input type="number" name="angle" step={1} defaultValue={0} />
+            </FormField>
+            <FormField isRequired label="Center x-coordinate (in)">
+              <Input
+                type="number"
+                name="centerX"
                 step={1}
                 defaultValue={0}
                 min={0}
                 max={BOARD_WIDTH_IN}
-                name="centerX"
               />
-            </FormControl>
-            <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Center y-coordinate (in)</FormLabel>
+            </FormField>
+            <FormField isRequired label="Center y-coordinate (in)">
               <Input
                 type="number"
+                name="centerY"
                 step={1}
                 defaultValue={0}
                 min={0}
                 max={BOARD_HEIGHT_IN}
-                name="centerY"
               />
-            </FormControl>
-            <FormControl marginTop="1rem" marginBottom="1rem">
-              <FormLabel>Notes</FormLabel>
+            </FormField>
+            <FormField label="Notes">
               <Textarea name="notes" />
-            </FormControl>
-            <Input name="gameId" type="hidden" value={gameId} />
+            </FormField>
             <Button width="100%" type="submit">
               Add terrain
             </Button>

--- a/app/routes/games.$gameId.terrains.new.tsx
+++ b/app/routes/games.$gameId.terrains.new.tsx
@@ -32,6 +32,7 @@ import * as R from "ramda";
 import db from "~/.server/db";
 import Spinner from "~/components/Spinner";
 import TableTop from "~/components/Tabletop";
+import PageHeading from "~/components/PageHeading";
 
 const INCHES_PER_FOOT = 12;
 const BOARD_WIDTH_IN = 6 * INCHES_PER_FOOT;
@@ -89,14 +90,7 @@ export default function NewTerrain() {
 
   return (
     <Container>
-      <Heading
-        as="h1"
-        size={{ base: "lg", lg: "2xl" }}
-        margin="1rem"
-        textAlign="center"
-      >
-        Add terrain
-      </Heading>
+      <PageHeading>Add terrain</PageHeading>
       <VStack>
         <ClientOnly fallback={<Spinner minHeight={MIN_TABLE_HEIGHT} />}>
           {() => <TableTop minHeight={MIN_TABLE_HEIGHT} />}

--- a/app/routes/games.$gameId.terrains.new.tsx
+++ b/app/routes/games.$gameId.terrains.new.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   VStack,
   Select,
-  Button,
   Textarea,
   TableContainer,
   Table,
@@ -27,10 +26,13 @@ import invariant from "tiny-invariant";
 import * as R from "ramda";
 
 import db from "~/.server/db";
-import Spinner from "~/components/Spinner";
-import TableTop from "~/components/Tabletop";
-import PageHeading from "~/components/PageHeading";
-import FormField from "~/components/FormField";
+import {
+  Spinner,
+  TableTop,
+  PageHeading,
+  FormField,
+  Button,
+} from "~/components";
 
 const INCHES_PER_FOOT = 12;
 const BOARD_WIDTH_IN = 6 * INCHES_PER_FOOT;
@@ -159,9 +161,7 @@ export default function NewTerrain() {
             <FormField label="Notes">
               <Textarea name="notes" />
             </FormField>
-            <Button width="100%" type="submit">
-              Add terrain
-            </Button>
+            <Button type="submit">Add terrain</Button>
           </Form>
           {terrains.length ? (
             <>
@@ -199,7 +199,7 @@ export default function NewTerrain() {
             </>
           ) : null}
           <Link to={`/games/${gameId}/play`}>
-            <Button width="100%" marginTop="1rem" marginBottom="1rem">
+            <Button marginTop="1rem" marginBottom="1rem">
               Start game
             </Button>
           </Link>

--- a/app/routes/games.new.tsx
+++ b/app/routes/games.new.tsx
@@ -1,18 +1,11 @@
-import {
-  Container,
-  Heading,
-  FormControl,
-  FormLabel,
-  Input,
-  Button,
-  Textarea,
-} from "@chakra-ui/react";
+import { Container, Input, Button, Textarea } from "@chakra-ui/react";
 import { MetaFunction, ActionFunction, redirect } from "@remix-run/node";
 import { Form } from "@remix-run/react";
 import * as R from "ramda";
 
 import db from "../.server/db";
 import PageHeading from "~/components/PageHeading";
+import FormField from "~/components/FormField";
 
 export const meta: MetaFunction = () => {
   return [
@@ -39,14 +32,12 @@ function NewGamePage() {
     <Container>
       <PageHeading>Set up a new game</PageHeading>
       <Form method="post">
-        <FormControl isRequired marginTop="1rem" marginBottom="1rem">
-          <FormLabel>Name</FormLabel>
+        <FormField isRequired label="Name">
           <Input type="text" name="name" />
-        </FormControl>
-        <FormControl marginTop="1rem" marginBottom="1rem">
-          <FormLabel>Description</FormLabel>
+        </FormField>
+        <FormField label="Description">
           <Textarea name="description" />
-        </FormControl>
+        </FormField>
         <Button width="100%" type="submit">
           Create game
         </Button>

--- a/app/routes/games.new.tsx
+++ b/app/routes/games.new.tsx
@@ -12,6 +12,7 @@ import { Form } from "@remix-run/react";
 import * as R from "ramda";
 
 import db from "../.server/db";
+import PageHeading from "~/components/PageHeading";
 
 export const meta: MetaFunction = () => {
   return [
@@ -36,14 +37,7 @@ export const action: ActionFunction = async ({ request }) =>
 function NewGamePage() {
   return (
     <Container>
-      <Heading
-        as="h1"
-        size={{ base: "lg", lg: "2xl" }}
-        margin="1rem"
-        textAlign="center"
-      >
-        Set up a new game
-      </Heading>
+      <PageHeading>Set up a new game</PageHeading>
       <Form method="post">
         <FormControl isRequired marginTop="1rem" marginBottom="1rem">
           <FormLabel>Name</FormLabel>

--- a/app/routes/games.new.tsx
+++ b/app/routes/games.new.tsx
@@ -1,11 +1,10 @@
-import { Container, Input, Button, Textarea } from "@chakra-ui/react";
+import { Container, Input, Textarea } from "@chakra-ui/react";
 import { MetaFunction, ActionFunction, redirect } from "@remix-run/node";
 import { Form } from "@remix-run/react";
 import * as R from "ramda";
 
 import db from "../.server/db";
-import PageHeading from "~/components/PageHeading";
-import FormField from "~/components/FormField";
+import { PageHeading, FormField, Button } from "~/components";
 
 export const meta: MetaFunction = () => {
   return [
@@ -38,9 +37,7 @@ function NewGamePage() {
         <FormField label="Description">
           <Textarea name="description" />
         </FormField>
-        <Button width="100%" type="submit">
-          Create game
-        </Button>
+        <Button type="submit">Create game</Button>
       </Form>
     </Container>
   );

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,18 +1,11 @@
-import {
-  Container,
-  Heading,
-  FormControl,
-  FormLabel,
-  Input,
-  Button,
-  FormErrorMessage,
-} from "@chakra-ui/react";
+import { Container, Button, Input } from "@chakra-ui/react";
 import { MetaFunction, json, ActionFunctionArgs } from "@remix-run/node";
 import { Form, useActionData } from "@remix-run/react";
 import { AuthorizationError } from "remix-auth";
 
 import { authenticator } from "~/.server/auth";
 import { commitSession, getSession } from "~/.server/session";
+import FormField from "~/components/FormField";
 import PageHeading from "~/components/PageHeading";
 
 export const meta: MetaFunction = () => {
@@ -64,25 +57,12 @@ export default function LoginPage() {
     <Container>
       <PageHeading>Log in</PageHeading>
       <Form method="post">
-        <FormControl
-          isRequired
-          marginTop="1rem"
-          marginBottom="1rem"
-          isInvalid={!!errors}
-        >
-          <FormLabel>Email</FormLabel>
+        <FormField isRequired label="Email" errors={errors}>
           <Input type="email" name="email" />
-        </FormControl>
-        <FormControl
-          isRequired
-          marginTop="1rem"
-          marginBottom="1rem"
-          isInvalid={!!errors}
-        >
-          <FormLabel>Password</FormLabel>
+        </FormField>
+        <FormField isRequired label="Password" errors={errors}>
           <Input type="password" name="password" />
-          <FormErrorMessage>{errors}</FormErrorMessage>
-        </FormControl>
+        </FormField>
         <Button width="100%" type="submit">
           Log in
         </Button>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,12 +1,11 @@
-import { Container, Button, Input } from "@chakra-ui/react";
+import { Container, Input } from "@chakra-ui/react";
 import { MetaFunction, json, ActionFunctionArgs } from "@remix-run/node";
 import { Form, useActionData } from "@remix-run/react";
 import { AuthorizationError } from "remix-auth";
 
 import { authenticator } from "~/.server/auth";
 import { commitSession, getSession } from "~/.server/session";
-import FormField from "~/components/FormField";
-import PageHeading from "~/components/PageHeading";
+import { Button, FormField, PageHeading } from "~/components";
 
 export const meta: MetaFunction = () => {
   return [
@@ -20,7 +19,7 @@ export const meta: MetaFunction = () => {
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   try {
-    await authenticator.authenticate("form", request, {
+    return await authenticator.authenticate("form", request, {
       throwOnError: true,
       successRedirect: "/account",
     });
@@ -63,9 +62,7 @@ export default function LoginPage() {
         <FormField isRequired label="Password" errors={errors}>
           <Input type="password" name="password" />
         </FormField>
-        <Button width="100%" type="submit">
-          Log in
-        </Button>
+        <Button type="submit">Log in</Button>
       </Form>
     </Container>
   );

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -36,7 +36,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       const session = await getSession(request.headers.get("cookie"));
 
       return json(
-        { error: "Either the email or password are incorrect" },
+        { errors: ["Either the email or password are incorrect"] },
         {
           headers: {
             "Set-Cookie": await commitSession(session),
@@ -50,7 +50,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 };
 
 export default function LoginPage() {
-  const { error } = useActionData<typeof action>() || {};
+  const response: Response | { errors: string[] } | undefined =
+    useActionData<typeof action>();
+
+  if (response instanceof Response) {
+    throw response;
+  }
+
+  const { errors } = response || {};
 
   return (
     <Container>
@@ -67,7 +74,7 @@ export default function LoginPage() {
           isRequired
           marginTop="1rem"
           marginBottom="1rem"
-          isInvalid={!!error}
+          isInvalid={!!errors}
         >
           <FormLabel>Email</FormLabel>
           <Input type="email" name="email" />
@@ -76,11 +83,11 @@ export default function LoginPage() {
           isRequired
           marginTop="1rem"
           marginBottom="1rem"
-          isInvalid={!!error}
+          isInvalid={!!errors}
         >
           <FormLabel>Password</FormLabel>
           <Input type="password" name="password" />
-          <FormErrorMessage>{error}</FormErrorMessage>
+          <FormErrorMessage>{errors}</FormErrorMessage>
         </FormControl>
         <Button width="100%" type="submit">
           Log in

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -13,6 +13,7 @@ import { AuthorizationError } from "remix-auth";
 
 import { authenticator } from "~/.server/auth";
 import { commitSession, getSession } from "~/.server/session";
+import PageHeading from "~/components/PageHeading";
 
 export const meta: MetaFunction = () => {
   return [
@@ -61,14 +62,7 @@ export default function LoginPage() {
 
   return (
     <Container>
-      <Heading
-        as="h1"
-        size={{ base: "lg", lg: "2xl" }}
-        margin="1rem"
-        textAlign="center"
-      >
-        Log in
-      </Heading>
+      <PageHeading>Log in</PageHeading>
       <Form method="post">
         <FormControl
           isRequired

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,13 +1,4 @@
-import {
-  Container,
-  Heading,
-  FormControl,
-  FormLabel,
-  Input,
-  Button,
-  FormHelperText,
-  FormErrorMessage,
-} from "@chakra-ui/react";
+import { Container, Input, Button } from "@chakra-ui/react";
 import {
   MetaFunction,
   redirect,
@@ -21,6 +12,7 @@ import { ZodError } from "zod";
 import { authenticator } from "~/.server/auth";
 import db from "~/.server/db";
 import { commitSession, getSession } from "~/.server/session";
+import FormField from "~/components/FormField";
 import PageHeading from "~/components/PageHeading";
 
 interface FormErrors {
@@ -94,45 +86,20 @@ export default function SignupPage() {
     <Container>
       <PageHeading>Sign up</PageHeading>
       <Form method="post">
-        <FormControl
-          isRequired
-          marginTop="1rem"
-          marginBottom="1rem"
-          isInvalid={!!errors?.username}
-        >
-          <FormLabel>Username</FormLabel>
+        <FormField isRequired label="Username" errors={errors?.username}>
           <Input type="text" name="username" />
-          {errors?.username?.map((message) => (
-            <FormErrorMessage key={message}>{message}</FormErrorMessage>
-          ))}
-        </FormControl>
-        <FormControl
-          isRequired
-          marginTop="1rem"
-          marginBottom="1rem"
-          isInvalid={!!errors?.email}
-        >
-          <FormLabel>Email</FormLabel>
+        </FormField>
+        <FormField isRequired label="Email" errors={errors?.email}>
           <Input type="email" name="email" />
-          {errors?.email?.map((message) => (
-            <FormErrorMessage key={message}>{message}</FormErrorMessage>
-          ))}
-        </FormControl>
-        <FormControl
+        </FormField>
+        <FormField
           isRequired
-          marginTop="1rem"
-          marginBottom="1rem"
-          isInvalid={!!errors?.password}
+          label="Password"
+          helperText="Must have at least 8 characters"
+          errors={errors?.password}
         >
-          <FormLabel>Password</FormLabel>
           <Input type="password" name="password" />
-          {errors?.password?.map((message) => (
-            <FormErrorMessage key={message}>{message}</FormErrorMessage>
-          )) || (
-            <FormHelperText>Must have at least 8 characters</FormHelperText>
-          )}
-        </FormControl>
-        <Input type="hidden" name="signup" value="true" />
+        </FormField>
         <Button width="100%" type="submit">
           Create account
         </Button>

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -21,6 +21,7 @@ import { ZodError } from "zod";
 import { authenticator } from "~/.server/auth";
 import db from "~/.server/db";
 import { commitSession, getSession } from "~/.server/session";
+import PageHeading from "~/components/PageHeading";
 
 interface FormErrors {
   email?: string[];
@@ -91,14 +92,7 @@ export default function SignupPage() {
 
   return (
     <Container>
-      <Heading
-        as="h1"
-        size={{ base: "lg", lg: "2xl" }}
-        margin="1rem"
-        textAlign="center"
-      >
-        Sign up
-      </Heading>
+      <PageHeading>Sign up</PageHeading>
       <Form method="post">
         <FormControl
           isRequired

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,4 +1,4 @@
-import { Container, Input, Button } from "@chakra-ui/react";
+import { Container, Input } from "@chakra-ui/react";
 import {
   MetaFunction,
   redirect,
@@ -12,8 +12,7 @@ import { ZodError } from "zod";
 import { authenticator } from "~/.server/auth";
 import db from "~/.server/db";
 import { commitSession, getSession } from "~/.server/session";
-import FormField from "~/components/FormField";
-import PageHeading from "~/components/PageHeading";
+import { Button, FormField, PageHeading } from "~/components";
 
 interface FormErrors {
   email?: string[];
@@ -100,9 +99,7 @@ export default function SignupPage() {
         >
           <Input type="password" name="password" />
         </FormField>
-        <Button width="100%" type="submit">
-          Create account
-        </Button>
+        <Button type="submit">Create account</Button>
       </Form>
     </Container>
   );

--- a/cypress/e2e/armies.cy.ts
+++ b/cypress/e2e/armies.cy.ts
@@ -1,0 +1,89 @@
+import { faker } from "@faker-js/faker";
+
+describe("Armies", () => {
+  it("can be created", () => {
+    const oldArmyName = faker.company.name();
+    const armyName = faker.company.name();
+    const oldUnitName = faker.commerce.department();
+    const unitName = faker.commerce.department();
+    const miniatureName = faker.commerce.productName();
+    const overlyLongName = faker.lorem.words(50);
+
+    cy.login();
+    cy.findByRole("link", { name: "Build an army" }).click();
+
+    cy.location("pathname").should("equal", "/armies/new");
+    cy.findByRole("heading", { name: "Build a new army" });
+    cy.findByRole("textbox", { name: "Name" }).type(overlyLongName);
+    cy.findByRole("textbox", { name: "Game system" }).type(
+      faker.company.buzzPhrase(),
+    );
+    cy.findByRole("textbox", { name: "Faction" }).type(
+      faker.company.buzzNoun(),
+    );
+    cy.findByRole("textbox", { name: "Description" }).type(
+      faker.lorem.paragraph(),
+    );
+    cy.findByRole("button", { name: "Save" }).click();
+
+    cy.location("pathname").should("equal", "/armies/new");
+    cy.findByRole("textbox", { name: "Name" })
+      .should("have.value", oldArmyName)
+      .clear()
+      .type(armyName);
+    cy.findByRole("button", { name: "Add units" }).click();
+
+    cy.location("pathname").should("match", /armies\/\d+\/units\/new/);
+    cy.findByRole("heading", { name: `Add a unit to ${armyName}` });
+    cy.findByRole("textbox", { name: "Name" }).type(overlyLongName);
+    cy.findByRole("textbox", { name: "Stats" }).type(faker.lorem.sentences());
+    cy.findByRole("textbox", { name: "Gear" }).type(faker.lorem.sentences());
+    cy.findByRole("textbox", { name: "Notes" }).type(faker.lorem.paragraph());
+    cy.findByRole("combobox", { name: "Base shape" }).select("round");
+    cy.findByRole("spinbutton", { name: "Base length (mm)" }).type("32");
+    cy.findByRole("spinbutton", { name: "Base width (mm)" }).type("32");
+    // Cypress doesn't have a nice way of handling color pickers, so the
+    // recommended approach is to force the value + change event.
+    cy.findByLabelText("Model color*")
+      .invoke("val", "#ff0000")
+      .trigger("change");
+    cy.findByRole("button", { name: "Save" }).click();
+
+    // Check serverside validations
+    cy.findByText("String must contain at most 255 character(s)");
+    cy.findByRole("textbox", { name: "Name" }).clear().type(oldUnitName);
+    cy.findByRole("button", { name: "Save" }).click();
+
+    cy.location("pathname").should("match", /armies\/\d+\/units\/new/);
+    cy.findByRole("textbox", { name: "Name" })
+      .should("have.value", oldUnitName)
+      .clear()
+      .type(unitName);
+    cy.findByRole("button", { name: "Add models" }).click();
+
+    cy.location("pathname").should("match", /units\/\d+\/miniatures\/new/);
+    cy.findByRole("heading", { name: `Add a model to ${unitName}` });
+    cy.findByRole("textbox", { name: "Name" }).type(overlyLongName);
+    cy.findByRole("textbox", { name: "Stats" }).type(faker.lorem.sentences());
+    cy.findByRole("textbox", { name: "Gear" }).type(faker.lorem.sentences());
+    cy.findByRole("textbox", { name: "Notes" }).type(faker.lorem.paragraph());
+    cy.findByRole("spinbutton", { name: "How many?" }).type("5");
+    cy.findByRole("button", { name: "Save" }).click();
+
+    // Check serverside validations
+    cy.findByText("String must contain at most 255 character(s)");
+    cy.findByRole("textbox", { name: "Name" }).clear().type(miniatureName);
+    cy.findByRole("button", { name: "Save" }).click();
+
+    cy.location("pathname").should("match", /units\/\d+\/miniatures\/new/);
+    cy.findByRole("link", { name: "Back to unit" }).click();
+
+    cy.location("pathname").should("match", /armies\/\d+\/units\/new/);
+    cy.findByRole("link", { name: "Back to army" }).click();
+
+    cy.location("pathname").should("equal", "/armies/new");
+    cy.findByRole("link", { name: "Back to account" }).click();
+
+    cy.location("pathname").should("equal", "/account");
+  });
+});

--- a/cypress/e2e/armies.cy.ts
+++ b/cypress/e2e/armies.cy.ts
@@ -26,6 +26,11 @@ describe("Armies", () => {
     );
     cy.findByRole("button", { name: "Save" }).click();
 
+    // Check serverside validations
+    cy.findByText("String must contain at most 255 character(s)");
+    cy.findByRole("textbox", { name: "Name" }).clear().type(oldArmyName);
+    cy.findByRole("button", { name: "Save" }).click();
+
     cy.location("pathname").should("equal", "/armies/new");
     cy.findByRole("textbox", { name: "Name" })
       .should("have.value", oldArmyName)

--- a/cypress/e2e/user-accounts.cy.ts
+++ b/cypress/e2e/user-accounts.cy.ts
@@ -1,12 +1,6 @@
 import { faker } from "@faker-js/faker";
 
-const SEEDED_USER = {
-  username: "testuser",
-  email: "testuser@wargamebymail.com",
-  password: "supersecretsauce",
-};
-
-describe("User", () => {
+describe("User accounts", () => {
   it("can sign up", () => {
     const username = faker.internet.userName();
     const email = faker.internet.email();
@@ -55,23 +49,25 @@ describe("User", () => {
     cy.location("pathname").should("equal", "/login");
     cy.findByRole("heading", { name: "Log in" });
 
-    cy.findByLabelText("Email*").type(SEEDED_USER.email);
-    cy.findByLabelText("Password*").type(
-      "prettysurenotarealpasswordkthnxbyebbq",
-    );
-    cy.findByRole("button", { name: "Log in" }).click();
-    cy.findByText("Either the email or password are incorrect");
-    cy.findByLabelText("Password*").clear().type(SEEDED_USER.password);
-    cy.findByRole("button", { name: "Log in" }).click();
+    cy.fixture("user").then(({ username, email, password }) => {
+      cy.findByLabelText("Email*").type(email);
+      cy.findByLabelText("Password*").type(
+        "prettysurenotarealpasswordkthnxbyebbq",
+      );
+      cy.findByRole("button", { name: "Log in" }).click();
+      cy.findByText("Either the email or password are incorrect");
+      cy.findByLabelText("Password*").clear().type(password);
+      cy.findByRole("button", { name: "Log in" }).click();
 
-    cy.location("pathname").should("equal", "/account");
-    cy.findByRole("heading", { name: SEEDED_USER.username });
+      cy.location("pathname").should("equal", "/account");
+      cy.findByRole("heading", { name: username });
 
-    cy.findByRole("button", { name: SEEDED_USER.username }).click();
-    cy.findByRole("menuitem", { name: "Log out" }).click();
-    cy.location("pathname").should("equal", "/login");
-    cy.visit("/account");
-    cy.location("pathname").should("equal", "/login");
-    cy.findByRole("heading", { name: "Log in" });
+      cy.findByRole("button", { name: username }).click();
+      cy.findByRole("menuitem", { name: "Log out" }).click();
+      cy.location("pathname").should("equal", "/login");
+      cy.visit("/account");
+      cy.location("pathname").should("equal", "/login");
+      cy.findByRole("heading", { name: "Log in" });
+    });
   });
 });

--- a/cypress/e2e/user-accounts.cy.ts
+++ b/cypress/e2e/user-accounts.cy.ts
@@ -55,7 +55,7 @@ describe("User accounts", () => {
         "prettysurenotarealpasswordkthnxbyebbq",
       );
       cy.findByRole("button", { name: "Log in" }).click();
-      cy.findByText("Either the email or password are incorrect");
+      cy.findAllByText("Either the email or password are incorrect");
       cy.findByLabelText("Password*").clear().type(password);
       cy.findByRole("button", { name: "Log in" }).click();
 

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -1,0 +1,5 @@
+{
+  "username": "testuser",
+  "email": "testuser@wargamebymail.com",
+  "password": "supersecretsauce"
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,39 +1,28 @@
 import "@testing-library/cypress/add-commands";
 
 /// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+
+Cypress.Commands.add("login", (email, password) => {
+  cy.fixture("user").then(
+    ({ email: defaultEmail, password: defaultPassword }) => {
+      cy.visit("/login");
+      cy.location("pathname").should("equal", "/login");
+      cy.findByRole("heading", { name: "Log in" });
+
+      cy.findByRole("textbox", { name: "Email" }).type(email || defaultEmail);
+      cy.findByLabelText("Password*").type(password || defaultPassword);
+      cy.findByRole("button", { name: "Log in" }).click();
+
+      cy.location("pathname").should("equal", "/account");
+    },
+  );
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      login(email?: string, password?: string): Chainable<void>;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "remix-auth-form": "^1.5.0",
         "remix-utils": "^7.6.0",
         "tiny-invariant": "^1.3.3",
+        "validator": "^13.12.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -39,6 +40,7 @@
         "@types/ramda": "^0.30.0",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
+        "@types/validator": "^13.12.0",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "@typescript-eslint/parser": "^6.7.4",
         "autoprefixer": "^10.4.19",
@@ -5167,6 +5169,13 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
       "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-nH45Lk7oPIJ1RVOF6JgFI6Dy0QpHEzq4QecZhvguxYPDwT8c93prCMqAtiIttm39voZ+DDR+qkNnMpJmMBRqag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -16251,6 +16260,15 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "remix-auth-form": "^1.5.0",
     "remix-utils": "^7.6.0",
     "tiny-invariant": "^1.3.3",
+    "validator": "^13.12.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -68,6 +69,7 @@
     "@types/ramda": "^0.30.0",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
+    "@types/validator": "^13.12.0",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "autoprefixer": "^10.4.19",

--- a/prisma/migrations/20240724043942_add_army_and_related_models/migration.sql
+++ b/prisma/migrations/20240724043942_add_army_and_related_models/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE "armies" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "game_system" TEXT NOT NULL,
+    "faction" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+
+    CONSTRAINT "armies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "units" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "stats" TEXT NOT NULL,
+    "gear" TEXT NOT NULL,
+    "notes" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "base_length" TEXT NOT NULL,
+    "base_width" TEXT NOT NULL,
+    "base_shape_id" INTEGER NOT NULL,
+    "army_id" INTEGER NOT NULL,
+
+    CONSTRAINT "units_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "base_shapes" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "base_shapes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "miniatures" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "stats" TEXT NOT NULL,
+    "gear" TEXT NOT NULL,
+    "notes" TEXT NOT NULL,
+    "unit_id" INTEGER NOT NULL,
+
+    CONSTRAINT "miniatures_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "units" ADD CONSTRAINT "units_base_shape_id_fkey" FOREIGN KEY ("base_shape_id") REFERENCES "base_shapes"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "units" ADD CONSTRAINT "units_army_id_fkey" FOREIGN KEY ("army_id") REFERENCES "armies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "miniatures" ADD CONSTRAINT "miniatures_unit_id_fkey" FOREIGN KEY ("unit_id") REFERENCES "units"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240724044148_add_missing_base_shape_name/migration.sql
+++ b/prisma/migrations/20240724044148_add_missing_base_shape_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `name` to the `base_shapes` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "base_shapes" ADD COLUMN     "name" TEXT NOT NULL;

--- a/prisma/migrations/20240802062440_fix_base_dimension_data_types/migration.sql
+++ b/prisma/migrations/20240802062440_fix_base_dimension_data_types/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Changed the type of `base_length` on the `units` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `base_width` on the `units` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "units" DROP COLUMN "base_length",
+ADD COLUMN     "base_length" INTEGER NOT NULL,
+DROP COLUMN "base_width",
+ADD COLUMN     "base_width" INTEGER NOT NULL;

--- a/prisma/migrations/20240803033254_add_count_to_miniature_model/migration.sql
+++ b/prisma/migrations/20240803033254_add_count_to_miniature_model/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `count` to the `miniatures` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "miniatures" ADD COLUMN     "count" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,8 +92,8 @@ model Unit {
   gear        String
   notes       String
   color       String
-  baseLength  String      @map("base_length")
-  baseWidth   String      @map("base_width")
+  baseLength  Int         @map("base_length")
+  baseWidth   Int         @map("base_width")
   baseShape   BaseShape   @relation(fields: [baseShapeId], references: [id])
   baseShapeId Int         @map("base_shape_id")
   army        Army        @relation(fields: [armyId], references: [id])
@@ -121,6 +121,7 @@ model Miniature {
   stats     String
   gear      String
   notes     String
+  count     Int
   unit      Unit     @relation(fields: [unitId], references: [id])
   unitId    Int      @map("unit_id")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,3 +69,60 @@ model User {
 
   @@map("users")
 }
+
+model Army {
+  id          Int      @id @default(autoincrement())
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+  name        String
+  gameSystem  String   @map("game_system")
+  faction     String
+  description String
+  units       Unit[]
+
+  @@map("armies")
+}
+
+model Unit {
+  id          Int         @id @default(autoincrement())
+  createdAt   DateTime    @default(now()) @map("created_at")
+  updatedAt   DateTime    @updatedAt @map("updated_at")
+  name        String
+  stats       String
+  gear        String
+  notes       String
+  color       String
+  baseLength  String      @map("base_length")
+  baseWidth   String      @map("base_width")
+  baseShape   BaseShape   @relation(fields: [baseShapeId], references: [id])
+  baseShapeId Int         @map("base_shape_id")
+  army        Army        @relation(fields: [armyId], references: [id])
+  armyId      Int         @map("army_id")
+  miniatures  Miniature[]
+
+  @@map("units")
+}
+
+model BaseShape {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  name      String
+  units     Unit[]
+
+  @@map("base_shapes")
+}
+
+model Miniature {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  name      String
+  stats     String
+  gear      String
+  notes     String
+  unit      Unit     @relation(fields: [unitId], references: [id])
+  unitId    Int      @map("unit_id")
+
+  @@map("miniatures")
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -23,6 +23,9 @@ async function main() {
     await tx.terrainShape.createMany({
       data: [{ name: "rectangle" }, { name: "oval" }],
     });
+    await tx.baseShape.createMany({
+      data: [{ name: "square" }, { name: "round" }],
+    });
   });
 
   const {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       "remix-auth",
       "remix-auth-form",
       "bcryptjs",
+      "validator/lib/isHexColor",
     ],
   },
   server: {


### PR DESCRIPTION
This adds the ability to create armies from the accounts page, including adding units and adding models to those units. Still a bit rough, because I wanted to save editing for a later PR, so I didn't add info/edit pages for specific armies/units/miniatures, which makes the navigation a bit wonky.